### PR TITLE
Firestore collection group query

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Simplify connection between Akita and Firebase inside an Angular project
 Connect Firebase and Akita : 
 - [x] Firestore Collection
 - [x] Firestore Document
+- [x] Firestore Collection Group
 - [x] Akita Array with Subcollections
 - [ ] Authentication
 - [ ] Storage
@@ -103,6 +104,7 @@ Documentation for Collection can be found here :
 - ⚗️ [Collection Service Configuration](./doc/collection/service/config.md)
 - 💂‍♀️ [Collection Guard API](./doc/collection/guard/api.md)
 - ⚙️ [Collection Guard Configuration](./doc/collection/guard/config.md)
+- 🎂 [Collection Group API](./doc/collection-group/api.md)
 
 ## Subcollection
 

--- a/doc/collection-group/api.md
+++ b/doc/collection-group/api.md
@@ -1,0 +1,34 @@
+# Collection Group Service - Getting Started
+The `CollectionGroupService` is a simple service to sync a store with a collection group. 
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class MovieService extends CollectionGroupService<MovieState> {
+  collectionId = 'movies';
+
+  constructor(store: MovieStore) {
+    super(store);
+  }
+
+}
+```
+
+> This service provides **readonly** methods only as CollectionGroup cannot be updated. For more interactive operation use `CollectionService`.
+
+## Properties
+
+```typescript
+collectionId: string
+```
+The id of the collection group you want to sync with. This value is **mandatory**.
+
+## Methods
+```typescript
+syncCollection(query?: QueryGroupFn);
+```
+Sync the collection group query with the store.
+
+```typescript
+getValue(query?: QueryGroupFn): Promise<E[]>
+```
+Get a snapshot of the collection group query.

--- a/doc/collection/service/api.md
+++ b/doc/collection/service/api.md
@@ -29,6 +29,18 @@ this.parentQuery.selectActiveId().pipe(
 ).subscribe();
 ```
 
+### syncCollectionGroup
+`syncCollectionGroup` will subscribe to a firebase collection group and sync the store with the result.
+`
+```typescript
+syncCollectionGroup(queryGroupFn?: QueryGroupFn);
+syncCollectionGroup(collectionId?: string, queryGroupFn?: QueryGroupFn);
+```
+If not provided, the method will use the `currentPath` as collectionId.
+
+⚠️ If the `path` is a subcollection, `syncCollectionGroup` will take **the last part of the path** (eg: if path is `movies/{movieId}/stakeholders` then the collectionId will be `stakeholders`).
+
+
 ### syncDoc
 `syncDoc` will subscribe to a specific document, and update the store accordingly.
 

--- a/projects/akita-ng-fire/package.json
+++ b/projects/akita-ng-fire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akita-ng-fire",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "peerDependencies": {
     "@angular/common": "^8.0.0",
     "@angular/core": "^8.0.0",

--- a/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
@@ -21,7 +21,7 @@ export abstract class CollectionGroupService<S extends EntityState> {
 
   /** Sync the collection group with the store */
   public syncCollection(queryGroupFn?: QueryGroupFn) {
-    this.db.collectionGroup(this.collectionId, queryGroupFn).stateChanges()
+    return this.db.collectionGroup(this.collectionId, queryGroupFn).stateChanges()
     .pipe(withTransaction(syncFromAction.bind(this)));
   }
 

--- a/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
@@ -26,7 +26,7 @@ export abstract class CollectionGroupService<S extends EntityState> {
   }
 
   /** Return a snapshot of the collection group */
-  public async getValue(queryGroupFn?: QueryGroupFn): Promise<getEntityType<S> | getEntityType<S>[]> {
+  public async getValue(queryGroupFn?: QueryGroupFn): Promise<getEntityType<S>[]> {
     const snapshot = await this.db.collectionGroup(this.collectionId, queryGroupFn).get().toPromise();
     return snapshot.docs.map(doc => doc.data() as getEntityType<S>);
   }

--- a/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
@@ -1,0 +1,33 @@
+import { inject } from '@angular/core';
+import { EntityStore, EntityState, withTransaction, getEntityType } from '@datorama/akita';
+import { AngularFirestore, QueryGroupFn } from '@angular/fire/firestore';
+import { syncFromAction } from '../utils/sync-from-action';
+
+export abstract class CollectionGroupService<S extends EntityState> {
+  protected db: AngularFirestore;
+  abstract collectionId: string;
+
+  constructor(protected store: EntityStore<S>) {
+    try {
+      this.db = inject(AngularFirestore);
+    } catch (err) {
+      throw new Error('CollectionGroupService requires AngularFirestore.');
+    }
+  }
+
+  get idKey() {
+    return this.store.idKey;
+  }
+
+  /** Sync the collection group with the store */
+  public syncCollection(queryGroupFn?: QueryGroupFn) {
+    this.db.collectionGroup(this.collectionId, queryGroupFn).stateChanges()
+    .pipe(withTransaction(syncFromAction.bind(this)));
+  }
+
+  /** Return a snapshot of the collection group */
+  public async getValue(queryGroupFn?: QueryGroupFn): Promise<getEntityType<S> | getEntityType<S>[]> {
+    const snapshot = await this.db.collectionGroup(this.collectionId, queryGroupFn).get().toPromise();
+    return snapshot.docs.map(doc => doc.data() as getEntityType<S>);
+  }
+}

--- a/projects/akita-ng-fire/src/lib/collection-group/index.ts
+++ b/projects/akita-ng-fire/src/lib/collection-group/index.ts
@@ -1,0 +1,1 @@
+export * from './collection-group.service';

--- a/projects/akita-ng-fire/src/lib/collection/collection.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.service.ts
@@ -125,12 +125,9 @@ export class CollectionService<S extends EntityState<any, string>>  {
   syncCollectionGroup(
     idOrQuery?: string | QueryGroupFn, queryGroupFn?: QueryGroupFn
   ): Observable<DocumentChangeAction<getEntityType<S>>[]> {
-    const collectionId = (typeof idOrQuery === 'string') ? idOrQuery : this.currentPath;
+    const path = (typeof idOrQuery === 'string') ? idOrQuery : this.currentPath;
     const query = typeof idOrQuery === 'function' ? idOrQuery : queryGroupFn;
-    // If no collectionId is provided, and currentPath is subcollection throw.
-    if (collectionId.indexOf('/') !== -1) {
-      throw new Error(`CollectionId ${collectionId} cannot contains '/'.`);
-    }
+    const collectionId = path.split('/').pop();
     return this.db.collectionGroup<getEntityType<S>>(collectionId, query)
       .stateChanges()
       .pipe(withTransaction(syncFromAction.bind(this)));

--- a/projects/akita-ng-fire/src/lib/index.ts
+++ b/projects/akita-ng-fire/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './collection';
 export * from './subcollection';
+export * from './collection-group';
 export * from './utils';

--- a/projects/akita-ng-fire/src/lib/utils/index.ts
+++ b/projects/akita-ng-fire/src/lib/utils/index.ts
@@ -3,3 +3,5 @@ export * from './query';
 export * from './path-with-params';
 export * from './redirect-if-empty';
 export * from './cancellation';
+export * from './sync-from-action';
+export * from './types';

--- a/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
@@ -1,0 +1,32 @@
+import { DocumentChangeAction } from '@angular/fire/firestore';
+import { getEntityType, getIDType } from '@datorama/akita';
+import { FirestoreService } from './types';
+
+// Credit to @arielgueta https://dev.to/arielgueta/getting-started-with-akita-and-firebase-3pe2
+export function syncFromAction<S>(
+  this: FirestoreService<S>,
+  actions: DocumentChangeAction<getEntityType<S>>[]
+) {
+  this.store.setLoading(false);
+  if (actions.length === 0) {
+    return;
+  }
+  for (const action of actions) {
+    const id: getIDType<S> = action.payload.doc.id as any;
+    const entity = action.payload.doc.data();
+
+    switch (action.type) {
+      case 'added': {
+        this.store.upsert(id, { [this.idKey]: id, ...entity });
+        break;
+      }
+      case 'removed': {
+        this.store.remove(id);
+        break;
+      }
+      case 'modified': {
+        this.store.update(id, entity);
+      }
+    }
+  }
+}

--- a/projects/akita-ng-fire/src/lib/utils/types.ts
+++ b/projects/akita-ng-fire/src/lib/utils/types.ts
@@ -1,0 +1,11 @@
+import { AngularFirestore, DocumentChangeAction } from '@angular/fire/firestore';
+import { EntityStore, EntityState, getEntityType } from '@datorama/akita';
+import { Observable } from 'rxjs';
+
+export interface FirestoreService<S extends EntityState<any> = any> {
+  db: AngularFirestore;
+  store: EntityStore<S>;
+  idKey: string;
+  syncCollection(query?: any): Observable<DocumentChangeAction<getEntityType<S>>[]>;
+  getValue(query?: any): Promise<getEntityType<S> | getEntityType<S>[]>;
+}

--- a/projects/akita-ng-fire/src/public-api.ts
+++ b/projects/akita-ng-fire/src/public-api.ts
@@ -4,4 +4,5 @@
 
 export * from './lib/collection';
 export * from './lib/subcollection';
+export * from './lib/collection-group';
 export * from './lib/utils';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,6 +41,10 @@ import { AkitaNgRouterStoreModule } from '@datorama/akita-ng-router-store';
       {
         path: 'catalog',
         loadChildren: () => import('./many-active/catalog.module').then(m => m.CatalogModule)
+      },
+      {
+        path: 'company',
+        loadChildren: () => import('./collection-group/company.module').then(m => m.CompanyModule)
       }
     ], { paramsInheritanceStrategy: 'always' }),
     AkitaNgRouterStoreModule.forRoot()

--- a/src/app/collection-group/+state/company.query.ts
+++ b/src/app/collection-group/+state/company.query.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { QueryEntity } from '@datorama/akita';
+import { CompanyStore, CompanyState } from './company.store';
+
+@Injectable({ providedIn: 'root' })
+export class CompanyQuery extends QueryEntity<CompanyState> {
+
+  constructor(protected store: CompanyStore) {
+    super(store);
+  }
+
+}

--- a/src/app/collection-group/+state/company.service.ts
+++ b/src/app/collection-group/+state/company.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { CompanyStore, CompanyState } from './company.store';
+import { CollectionGroupService } from 'akita-ng-fire';
+
+@Injectable({ providedIn: 'root' })
+export class CompanyService extends CollectionGroupService<CompanyState> {
+  readonly collectionId = 'stakeholders';
+
+  constructor(store: CompanyStore) {
+    super(store);
+  }
+
+}

--- a/src/app/collection-group/+state/company.store.ts
+++ b/src/app/collection-group/+state/company.store.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { EntityState, ActiveState, EntityStore, StoreConfig } from '@datorama/akita';
+import { Stakeholder } from 'src/app/subcollection/+state';
+
+export interface CompanyState extends EntityState<Stakeholder, string>, ActiveState<string> {}
+
+@Injectable({ providedIn: 'root' })
+@StoreConfig({ name: 'company' })
+export class CompanyStore extends EntityStore<CompanyState> {
+
+  constructor() {
+    super();
+  }
+
+}
+

--- a/src/app/collection-group/+state/index.ts
+++ b/src/app/collection-group/+state/index.ts
@@ -1,0 +1,3 @@
+export * from './company.store';
+export * from './company.service';
+export * from './company.query';

--- a/src/app/collection-group/company-list/company-list.component.html
+++ b/src/app/collection-group/company-list/company-list.component.html
@@ -1,0 +1,6 @@
+<mat-list>
+  <mat-list-item *ngFor="let company of companies$ | async">
+    <h4 mat-line>{{ company.name }}</h4>
+    <small>{{ company.id }}</small>
+  </mat-list-item>
+</mat-list>

--- a/src/app/collection-group/company-list/company-list.component.spec.ts
+++ b/src/app/collection-group/company-list/company-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CompanyListComponent } from './company-list.component';
+
+describe('CompanyListComponent', () => {
+  let component: CompanyListComponent;
+  let fixture: ComponentFixture<CompanyListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CompanyListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CompanyListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/collection-group/company-list/company-list.component.ts
+++ b/src/app/collection-group/company-list/company-list.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CompanyService, CompanyQuery } from '../+state';
+import { Observable, Subscription } from 'rxjs';
+import { Stakeholder } from 'src/app/subcollection/+state';
+
+@Component({
+  selector: 'company-list',
+  templateUrl: './company-list.component.html',
+  styleUrls: ['./company-list.component.css']
+})
+export class CompanyListComponent implements OnInit, OnDestroy {
+
+  private sub: Subscription;
+  companies$: Observable<Stakeholder[]>;
+
+  constructor(
+    private service: CompanyService,
+    private query: CompanyQuery
+  ) { }
+
+  ngOnInit() {
+    this.sub = this.service.syncCollection().subscribe();
+    this.companies$ = this.query.selectAll();
+  }
+
+  ngOnDestroy() {
+    this.sub.unsubscribe();
+  }
+}

--- a/src/app/collection-group/company.module.ts
+++ b/src/app/collection-group/company.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { CompanyListComponent } from './company-list/company-list.component';
+import { MatListModule } from '@angular/material/list';
+
+@NgModule({
+  declarations: [CompanyListComponent],
+  imports: [
+    CommonModule,
+    MatListModule,
+    RouterModule.forChild([
+      { path: '', redirectTo: 'list', pathMatch: 'full' },
+      { path: 'list', component: CompanyListComponent }
+    ])
+  ]
+})
+export class CompanyModule { }

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -2,3 +2,9 @@
   display: block;
   padding: 20px;
 }
+
+article {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,7 +1,10 @@
 <section>
   <h1>Welcome</h1>
   <p>Here you can see examples of apps using akita-ng-fire</p>
-  <a mat-button routerLink="/movies">Collection of movies</a>
-  <a mat-button routerLink="/catalog">Catalog of movies</a>
+  <article>
+    <a mat-button routerLink="/movies">Collection of movies</a>
+    <a mat-button routerLink="/company">Collection Group of companies participating to a movie</a>
+    <a mat-button routerLink="/catalog">Catalog of movies</a>
+  </article>
 </section>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "es2015",
+    "strictBindCallApply": true,
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "dom"],
     "paths": {

--- a/tslint.json
+++ b/tslint.json
@@ -12,13 +12,13 @@
     "directive-selector": [
       true,
       "attribute",
-      ["app", "movie", "stakeholder", "catalog"],
+      ["app", "movie", "stakeholder", "catalog", "company"],
       "camelCase"
     ],
     "component-selector": [
       true,
       "element",
-      ["app", "movie", "stakeholder", "catalog"],
+      ["app", "movie", "stakeholder", "catalog", "company"],
       "kebab-case"
     ],
     "import-blacklist": [


### PR DESCRIPTION
Add support for firestore collection group query: 
- [X] Create a `CollectionGroupService`.
- [X] Add a `syncCollectionGroup` method to `CollectionService`.
- [X] Update the doc.
- [X] `syncFromAction` is now part of the utils.