### PR TITLE
Add Hooks for atomic write operations

### DIFF
--- a/projects/akita-ng-fire/package.json
+++ b/projects/akita-ng-fire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akita-ng-fire",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "peerDependencies": {
     "@angular/common": "^8.0.0",
     "@angular/core": "^8.0.0",

--- a/projects/akita-ng-fire/src/lib/utils/types.ts
+++ b/projects/akita-ng-fire/src/lib/utils/types.ts
@@ -1,6 +1,7 @@
 import { AngularFirestore, DocumentChangeAction } from '@angular/fire/firestore';
 import { EntityStore, EntityState, getEntityType } from '@datorama/akita';
 import { Observable } from 'rxjs';
+import { firestore } from 'firebase';
 
 export interface FirestoreService<S extends EntityState<any> = any> {
   db: AngularFirestore;
@@ -9,3 +10,5 @@ export interface FirestoreService<S extends EntityState<any> = any> {
   syncCollection(query?: any): Observable<DocumentChangeAction<getEntityType<S>>[]>;
   getValue(query?: any): Promise<getEntityType<S> | getEntityType<S>[]>;
 }
+
+export type AtomicWrite = firestore.Transaction | firestore.WriteBatch;

--- a/src/app/collection/+state/movie.service.ts
+++ b/src/app/collection/+state/movie.service.ts
@@ -12,8 +12,7 @@ export class MovieService extends CollectionService<MovieState> {
 
   async onDelete(id: string, write: AtomicWrite) {
     const snapshot = await this.db.collection(`movies/${id}/stakeholders`).ref.get();
-    const operations = snapshot.docs.map(doc => write.delete(doc.ref));
-    return Promise.all(operations);
+    return snapshot.docs.map(doc => write.delete(doc.ref));
   }
 
 }

--- a/src/app/collection/+state/movie.service.ts
+++ b/src/app/collection/+state/movie.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MovieStore, MovieState } from './movie.store';
-import { AngularFirestore } from '@angular/fire/firestore';
-import { CollectionConfig, CollectionService } from 'akita-ng-fire';
-import { Observable } from 'rxjs';
+import { CollectionConfig, CollectionService, AtomicWrite } from 'akita-ng-fire';
 
 @Injectable({ providedIn: 'root' })
 @CollectionConfig({ path: 'movies' })
@@ -10,6 +8,12 @@ export class MovieService extends CollectionService<MovieState> {
 
   constructor(store: MovieStore) {
     super(store);
+  }
+
+  async onDelete(id: string, write: AtomicWrite) {
+    const snapshot = await this.db.collection(`movies/${id}/stakeholders`).ref.get();
+    const operations = snapshot.docs.map(doc => write.delete(doc.ref));
+    return Promise.all(operations);
   }
 
 }

--- a/src/app/subcollection/+state/stakeholder.model.ts
+++ b/src/app/subcollection/+state/stakeholder.model.ts
@@ -10,6 +10,7 @@ export interface Stakeholder {
  */
 export function createStakeholder(params: Partial<Stakeholder>) {
   return {
-
+    name: 'Default Name',
+    ...params
   } as Stakeholder;
 }

--- a/src/app/subcollection/stakeholder-create/stakeholder-create.component.ts
+++ b/src/app/subcollection/stakeholder-create/stakeholder-create.component.ts
@@ -7,7 +7,7 @@ import { StakeholderForm } from '../stakeholder.form';
   selector: 'stakeholder-create',
   templateUrl: './stakeholder-create.component.html',
   styleUrls: ['./stakeholder-create.component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.Default
 })
 export class StakeholderCreateComponent {
   public form = new StakeholderForm();

--- a/src/app/subcollection/stakeholder-edit/stakeholder-edit.component.ts
+++ b/src/app/subcollection/stakeholder-edit/stakeholder-edit.component.ts
@@ -3,6 +3,7 @@ import { StakeholderQuery, StakeholderService, Stakeholder } from '../+state';
 import { Observable, Subscription } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 import { StakeholderForm } from '../stakeholder.form';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'stakeholder-edit',
@@ -17,7 +18,9 @@ export class StakeholderEditComponent implements OnInit, OnDestroy {
 
   constructor(
     private service: StakeholderService,
-    private query: StakeholderQuery
+    private query: StakeholderQuery,
+    private routes: ActivatedRoute,
+    private router: Router
   ) { }
 
   ngOnInit() {
@@ -31,10 +34,11 @@ export class StakeholderEditComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
-  update() {
+  async update() {
     const id = this.query.getActiveId();
     const update = this.form.value;
-    this.service.update(id, update);
+    await this.service.update({id, ...update});
+    this.router.navigate(['../../list'], { relativeTo: this.routes });
   }
 
 }


### PR DESCRIPTION
fix #8 -> Hooks for atomic write operations.
fix #9 -> By default the write operations are batch, and can be overrided to transaction.
