### PR TITLE
Pass contextual data to read/write hooks. closes #14

### DIFF
--- a/projects/akita-ng-fire/src/lib/utils/types.ts
+++ b/projects/akita-ng-fire/src/lib/utils/types.ts
@@ -12,3 +12,8 @@ export interface FirestoreService<S extends EntityState<any> = any> {
 }
 
 export type AtomicWrite = firestore.Transaction | firestore.WriteBatch;
+
+export type WriteOpts = {
+  write: AtomicWrite,
+  ctx?: any
+};


### PR DESCRIPTION
Be able to pass options for cascading writings.