### PR TITLE
allow setting path getter only for CollectionService

### DIFF
--- a/projects/akita-ng-fire/src/lib/collection/collection.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.service.ts
@@ -31,6 +31,7 @@ import { Observable, isObservable, of, combineLatest } from 'rxjs';
 import { tap, map, switchMap } from 'rxjs/operators';
 import { getStoreName } from '../utils/store-options';
 import { pathWithParams } from '../utils/path-with-params';
+import { hasChildGetter } from '../utils/has-path-getter';
 
 export type CollectionState<E = any> = EntityState<E, string> & ActiveState<string>;
 export type orObservable<Input, Output> = Input extends Observable<infer I> ? Observable<Output> : Output;
@@ -51,7 +52,7 @@ export class CollectionService<S extends EntityState<any, string>>  {
     private collectionPath?: string,
     db?: AngularFirestore
   ) {
-    if (!this.constructor['path'] && !this.collectionPath) {
+    if (!hasChildGetter(this, CollectionService, 'path') && !this.constructor['path'] && !this.collectionPath) {
       throw new Error('You should provide a path to the collection');
     }
     try {

--- a/projects/akita-ng-fire/src/lib/utils/has-path-getter.ts
+++ b/projects/akita-ng-fire/src/lib/utils/has-path-getter.ts
@@ -1,0 +1,24 @@
+/**
+ * Same as Object.getOwnPropertyDescriptor, but recursively checks prototype chain excluding passed currentClass
+ * @param instance Instance to check on
+ * @param params Property name to check
+ * @param currentClass Checks prototype chain until this class
+ * @example getPropertyDescriptor(this, 'path', CollectionService)
+ */
+export function getPropertyDescriptor(instance: any, property: string, currentClass: any = Object): PropertyDescriptor {
+  const prototype = Object.getPrototypeOf(instance);
+  if (!prototype || !(prototype instanceof currentClass)) return;
+  return Object.getOwnPropertyDescriptor(prototype, property) || getPropertyDescriptor(prototype, property, currentClass);
+}
+
+/**
+ * Check prototype chain for a specific getter function, excluding parent class
+ * @param instance Instance of the class to check on
+ * @param parentClass Parent class of the instance
+ * @param property Property name to check
+ * @example hasChildGetter(this, CollectionService, 'path')
+ */
+export function hasChildGetter(instance: any, parentClass: any, property: string): boolean {
+  const descriptor = getPropertyDescriptor(instance, property, parentClass);
+  return descriptor && descriptor.get && true;
+}


### PR DESCRIPTION
Adds `hasChildGetter` method, which recursively checks on prototype chain for a getter (excluding the passed base class), without invoking it.