### PR TITLE
Accept auth provider object in signin method

### DIFF
--- a/doc/authentication/api.md
+++ b/doc/authentication/api.md
@@ -52,13 +52,23 @@ export class AuthQuery extends Query<AuthState> {
 
 ### Create
 
-#### Providers
+#### Providers Name
 `FireAuthService` provides a single method to signin with a provider. Just type the provider you want to use as first parameter : 
 ```typescript
-service.signin('microsoft');
+service.signin('apple');
 ```
 
 > When user authenticates for the first time, a document in the collection will be created
+
+#### Provider Object
+If you want to add custom options on your provider you can can a provider object as argument of the signin method instead : 
+```typescript
+import { getAuthProvider } from 'akita-ng-fire';
+
+const provider = getAuthProvider('microsoft');
+provider.setCustomParameters({ tenant: 'TENANT_ID' });
+service.signin(provider);
+```
 
 #### Email & Password
 When using email & password, you first need to signup, then signin : 

--- a/projects/akita-ng-fire/package.json
+++ b/projects/akita-ng-fire/package.json
@@ -2,10 +2,10 @@
   "name": "akita-ng-fire",
   "version": "2.0.0-rc.2",
   "peerDependencies": {
-    "@angular/common": ">=6.0.0 <9 || ^9.0.0-0",
-    "@angular/core": ">=6.0.0 <9 || ^9.0.0-0",
-    "@angular/router": ">=6.0.0 <9 || ^9.0.0-0",
-    "@angular/fire": "^5.2.1",
+    "@angular/common": ">=6.0.0 <10",
+    "@angular/core": ">=6.0.0 <10",
+    "@angular/router": ">=6.0.0 <10",
+    "@angular/fire": ">=6.0.0",
     "@datorama/akita": ">= 4.1.0",
     "firebase": ">= 7.6.1 <8",
     "typescript": ">= 3.4.0"


### PR DESCRIPTION
Should fix #77 :
```typescript
import { getAuthProvider } from 'akita-ng-fire';

const provider = getAuthProvider('microsoft');
provider.setCustomParameters({ tenant: 'TENANT_ID' });
service.signin(provider);
```