### PR TITLE
Issue 119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Change Log 
+
+<a name="3.0.2"></a>
+
+Added `resetOnUpdate` config to `CollectionService`. With this config you can choose whether you totally you want to remove and entity and add a new one with the new state,
+or, and this is default, when set to false, you let akita handle how they update their stores by design. Meaning if your new state updating the store, the keys that maybe got removed in the new state are still present in the akita store. So if you want the new state to be the only source of truth, set this config to true.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2298,9 +2298,9 @@
       }
     },
     "@datorama/akita": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@datorama/akita/-/akita-5.1.1.tgz",
-      "integrity": "sha512-iInGx8cUctrziCx+shy9LaNsmBnqmQeBLVzT+tNx6wmzAdGV/+C0D3hENXM+rbBWOMCubkj7XHG7XaCtC76lew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@datorama/akita/-/akita-5.2.0.tgz",
+      "integrity": "sha512-jPizvOCptW2TRwRKz8ecBxKPlIaJ72Al10KqBpYrebFQUX93tseQBLLEDSgGa5HD4Mty2uPdgj845jT5XHIFeQ==",
       "requires": {
         "schematics-utilities": "^1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser": "^10.0.1",
     "@angular/platform-browser-dynamic": "^10.0.1",
     "@angular/router": "^10.0.1",
-    "@datorama/akita": "^5.1.1",
+    "@datorama/akita": "^5.2.0",
     "@datorama/akita-ng-router-store": "^5.1.6",
     "firebase": "^7.15.5",
     "rxjs": "~6.5.5",

--- a/projects/akita-ng-fire/package.json
+++ b/projects/akita-ng-fire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akita-ng-fire",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "peerDependencies": {
     "@angular/common": ">=6.0.0 <11",
     "@angular/core": ">=6.0.0 <11",

--- a/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection-group/collection-group.service.ts
@@ -33,6 +33,10 @@ export abstract class CollectionGroupService<S extends EntityState> {
     }
   }
 
+  get resetOnUpdate(): boolean {
+    return this.constructor['resetOnUpdate'] || false;
+  }
+
   /** Sync the collection group with the store */
   public syncCollection(queryGroupFn?: QueryGroupFn | Partial<SyncOptions>);
   public syncCollection(queryGroupFn: QueryGroupFn, storeOptions?: Partial<SyncOptions>);
@@ -57,8 +61,9 @@ export abstract class CollectionGroupService<S extends EntityState> {
     if (storeOptions.loading) {
       setLoading(storeName, true);
     }
+
     return this.db.collectionGroup(this.collectionId, query).stateChanges().pipe(
-      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, (entity) => this.formatFromFirestore(entity)))
+      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, this.resetOnUpdate, (entity) => this.formatFromFirestore(entity)))
     );
   }
 

--- a/projects/akita-ng-fire/src/lib/collection/collection.config.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.config.ts
@@ -9,7 +9,7 @@ export interface CollectionOptions {
    * and add a new one in other to make sure
    * to get the rid of the any old keys that maybe still persist.
   */
-  removeAndAdd: boolean
+ resetOnUpdate: boolean
 }
 
 /** Set the configuration for the collection service */

--- a/projects/akita-ng-fire/src/lib/collection/collection.config.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.config.ts
@@ -4,6 +4,12 @@ export interface CollectionOptions {
   path: string;
   /** The key to use as an id for the document in Firestore. Default is store.idKey */
   idKey?: string;
+  /** 
+   * If true we will remove the entity from the store 
+   * and add a new one in other to make sure
+   * to get the rid of the any old keys that maybe still persist.
+  */
+  removeAndAdd: boolean
 }
 
 /** Set the configuration for the collection service */

--- a/projects/akita-ng-fire/src/lib/collection/collection.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.service.ts
@@ -15,7 +15,6 @@ import {
 } from '@datorama/akita';
 import { firestore } from 'firebase/app';
 import 'firebase/firestore';
-import { CollectionOptions } from './collection.config';
 import { getIdAndPath } from '../utils/id-or-path';
 import {
   syncStoreFromDocAction,
@@ -99,6 +98,10 @@ export class CollectionService<S extends EntityState<EntityType, string>, Entity
     return this.path;
   }
 
+  get removeAndAdd(): boolean {
+    return this.constructor['removeAndAdd'] || false;
+  }
+
   /**
    * The Angular Fire collection
    * @notice If path is an observable, it becomes an observable.
@@ -121,14 +124,6 @@ export class CollectionService<S extends EntityState<EntityType, string>, Entity
    */
   public formatFromFirestore(entity: any): EntityType {
     return entity;
-  }
-
-  /** The config given by the `CollectonConfig` */
-  public get config(): CollectionOptions {
-    return {
-      path: this.constructor['path'],
-      idKey: this.constructor['idKey']
-    };
   }
 
   /**
@@ -208,7 +203,7 @@ export class CollectionService<S extends EntityState<EntityType, string>, Entity
     }
     // Start Listening
     return this.db.collection<EntityType>(path, queryFn).stateChanges().pipe(
-      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, (entity) => this.formatFromFirestore(entity)))
+      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, this.removeAndAdd, (entity) => this.formatFromFirestore(entity)))
     );
   }
 
@@ -272,7 +267,7 @@ export class CollectionService<S extends EntityState<EntityType, string>, Entity
 
     const collectionId = path.split('/').pop();
     return this.db.collectionGroup<EntityType>(collectionId, query).stateChanges().pipe(
-      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, (entity) => this.formatFromFirestore(entity)))
+      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, this.removeAndAdd, (entity) => this.formatFromFirestore(entity)))
     );
   }
 

--- a/projects/akita-ng-fire/src/lib/collection/collection.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.service.ts
@@ -98,8 +98,8 @@ export class CollectionService<S extends EntityState<EntityType, string>, Entity
     return this.path;
   }
 
-  get removeAndAdd(): boolean {
-    return this.constructor['removeAndAdd'] || false;
+  get resetOnUpdate(): boolean {
+    return this.constructor['resetOnUpdate'] || false;
   }
 
   /**
@@ -203,7 +203,7 @@ export class CollectionService<S extends EntityState<EntityType, string>, Entity
     }
     // Start Listening
     return this.db.collection<EntityType>(path, queryFn).stateChanges().pipe(
-      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, this.removeAndAdd, (entity) => this.formatFromFirestore(entity)))
+      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, this.resetOnUpdate, (entity) => this.formatFromFirestore(entity)))
     );
   }
 
@@ -267,7 +267,7 @@ export class CollectionService<S extends EntityState<EntityType, string>, Entity
 
     const collectionId = path.split('/').pop();
     return this.db.collectionGroup<EntityType>(collectionId, query).stateChanges().pipe(
-      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, this.removeAndAdd, (entity) => this.formatFromFirestore(entity)))
+      withTransaction(actions => syncStoreFromDocAction(storeName, actions, this.idKey, this.resetOnUpdate, (entity) => this.formatFromFirestore(entity)))
     );
   }
 

--- a/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
@@ -54,7 +54,6 @@ export function updateStoreEntity(storeName: string, entityIds: string | string[
               ...data,
               [storeKey]: undefined
             }
-            console.log(newState)
           }
         }
       } else {

--- a/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
@@ -1,13 +1,11 @@
 import { DocumentChangeAction, DocumentSnapshot, Action } from '@angular/fire/firestore';
 import {
-  getStoreByName,
   getEntityType,
   StoreAction,
   runEntityStoreAction,
   EntityStoreAction,
   runStoreAction,
-  applyTransaction,
-  Store
+  applyTransaction
 } from '@datorama/akita';
 
 /** Set the loading parameter of a specific store */
@@ -36,41 +34,15 @@ export function removeStoreEntity(storeName: string, entityIds: string | string[
 }
 
 /** Update one or several entities in the store */
-export function updateStoreEntity(storeName: string, entityIds: string | string[], data: any) {
-
-  /* Since akita is not removing keys when they are not present in the update state
-  we nee to purge the keys and set it to undefined */
-  applyTransaction(() => {
-    const store: Store<any> = getStoreByName(storeName);
-    let newState = data;
-
-      // Are we only updating one entity ?
-      if (typeof entityIds === 'string') {
-        const storeValue = store.getValue().entities[entityIds];
-
-        for (let storeKey in storeValue) {
-          if (data[storeKey] === undefined) {
-            newState = {
-              ...data,
-              [storeKey]: undefined
-            }
-          }
-        }
-      } else {
-        entityIds.forEach(entityId => {
-          const storeValue = store.getValue().entities[entityId];
-          for (let storeKey in storeValue) {
-            if (data[storeKey] === undefined) {
-              newState = {
-                ...data,
-                [storeKey]: undefined
-              }
-            }
-          }
-        })
-      }
-      upsertStoreEntity(storeName, newState, entityIds)
-  })
+export function updateStoreEntity(removeAndAdd: boolean, storeName: string, entityIds: string | string[], data: any) {
+  if (removeAndAdd) {
+    applyTransaction(() => {
+      removeStoreEntity(storeName, entityIds);
+      upsertStoreEntity(storeName, data, entityIds)
+    })
+  } else {
+    runEntityStoreAction(storeName, EntityStoreAction.UpdateEntities, update => update(data))
+  }
 }
 
 /** Sync a specific store with actions from Firestore */
@@ -78,6 +50,7 @@ export function syncStoreFromDocAction<S>(
   storeName: string,
   actions: DocumentChangeAction<getEntityType<S>>[],
   idKey = 'id',
+  removeAndAdd: boolean,
   formatFromFirestore: Function
 ) {
   setLoading(storeName, false);
@@ -97,7 +70,7 @@ export function syncStoreFromDocAction<S>(
         break;
       }
       case 'modified': {
-        updateStoreEntity(storeName, id, entity);
+        updateStoreEntity(removeAndAdd, storeName, id, entity);
         break;
       }
     }

--- a/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
@@ -10,7 +10,6 @@ import {
   Store
 } from '@datorama/akita';
 
-
 /** Set the loading parameter of a specific store */
 export function setLoading(storeName: string, loading: boolean) {
   runStoreAction(storeName, StoreAction.Update, update => update({ loading }))
@@ -43,9 +42,7 @@ export function updateStoreEntity(storeName: string, entityIds: string | string[
   we nee to purge the keys and set it to undefined */
   applyTransaction(() => {
     const store: Store<any> = getStoreByName(storeName);
-    let newState: any;
-    // Check if we are working with an entity store
-    if (store.getValue()?.entities) {
+    let newState = data;
 
       // Are we only updating one entity ?
       if (typeof entityIds === 'string') {
@@ -74,7 +71,6 @@ export function updateStoreEntity(storeName: string, entityIds: string | string[
         })
       }
       upsertStoreEntity(storeName, newState, entityIds)
-    }
   })
 }
 
@@ -108,7 +104,6 @@ export function syncStoreFromDocAction<S>(
     }
   }
 }
-
 
 /** Sync a specific store with actions from Firestore */
 export function syncStoreFromDocActionSnapshot<S>(

--- a/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
@@ -1,5 +1,15 @@
 import { DocumentChangeAction, DocumentSnapshot, Action } from '@angular/fire/firestore';
-import { getEntityType, StoreAction, runEntityStoreAction, EntityStoreAction, runStoreAction, applyTransaction } from '@datorama/akita';
+import {
+  getStoreByName,
+  getEntityType,
+  StoreAction,
+  runEntityStoreAction,
+  EntityStoreAction,
+  runStoreAction,
+  applyTransaction,
+  Store
+} from '@datorama/akita';
+
 
 /** Set the loading parameter of a specific store */
 export function setLoading(storeName: string, loading: boolean) {
@@ -29,7 +39,23 @@ export function removeStoreEntity(storeName: string, entityIds: string | string[
 /** Update one or several entities in the store */
 export function updateStoreEntity(storeName: string, entityIds: string | string[], data: any) {
   applyTransaction(() => {
-    removeStoreEntity(storeName, entityIds);
+    const store: Store<any> = getStoreByName(storeName);
+
+    // Check if we are working with an entity store
+    if (store.getValue()?.entities) {
+
+      // Are we only updating one entity ?
+      if (typeof entityIds === 'string') {
+        const storeValue = store.getValue().entities[entityIds];
+        for (let storeKey in storeValue) {
+          if (!data[storeKey]) {
+            console.log(storeValue[storeKey])
+            storeValue[storeKey] = ''
+          }
+        }
+      }
+    }
+/*     removeStoreEntity(storeName, entityIds  */;
     upsertStoreEntity(storeName, data, entityIds)
   })
 }

--- a/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
@@ -38,25 +38,43 @@ export function removeStoreEntity(storeName: string, entityIds: string | string[
 
 /** Update one or several entities in the store */
 export function updateStoreEntity(storeName: string, entityIds: string | string[], data: any) {
+
+  /* Since akita is not removing keys when they are not present in the update state
+  we nee to purge the keys and set it to undefined */
   applyTransaction(() => {
     const store: Store<any> = getStoreByName(storeName);
-
+    let newState: any;
     // Check if we are working with an entity store
     if (store.getValue()?.entities) {
 
       // Are we only updating one entity ?
       if (typeof entityIds === 'string') {
         const storeValue = store.getValue().entities[entityIds];
+
         for (let storeKey in storeValue) {
-          if (!data[storeKey]) {
-            console.log(storeValue[storeKey])
-            storeValue[storeKey] = ''
+          if (data[storeKey] === undefined) {
+            newState = {
+              ...data,
+              [storeKey]: undefined
+            }
+            console.log(newState)
           }
         }
+      } else {
+        entityIds.forEach(entityId => {
+          const storeValue = store.getValue().entities[entityId];
+          for (let storeKey in storeValue) {
+            if (data[storeKey] === undefined) {
+              newState = {
+                ...data,
+                [storeKey]: undefined
+              }
+            }
+          }
+        })
       }
+      upsertStoreEntity(storeName, newState, entityIds)
     }
-/*     removeStoreEntity(storeName, entityIds  */;
-    upsertStoreEntity(storeName, data, entityIds)
   })
 }
 

--- a/projects/akita-ng-fire/src/lib/utils/sync-with-router.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-with-router.ts
@@ -10,7 +10,7 @@ export function syncWithRouter<Service extends CollectionService<CollectionState
   routerQuery: RouterQuery
 ): Observable<DocumentChangeAction<E>[]> {
   if (!this['store'].resettable) {
-    throw new Error(`Store ${this['store'].storeName} is required to be ressetable for syncWithRouter to work.`);
+    throw new Error(`Store ${this['store'].storeName} is required to be resettable for syncWithRouter to work.`);
   }
 
   const pathParams = getPathParams(this.path);

--- a/src/app/collection/+state/movie.service.ts
+++ b/src/app/collection/+state/movie.service.ts
@@ -12,7 +12,7 @@ const movieQuery: Query<Movie> = {
 };
 
 @Injectable({ providedIn: 'root' })
-@CollectionConfig({ path: 'movies' })
+@CollectionConfig({ path: 'movies', resetOnUpdate: true })
 export class MovieService extends CollectionService<MovieState> {
   syncQuery = syncQuery.bind(this, movieQuery);
 


### PR DESCRIPTION
Since akita is not removing keys when a new state updates the store, this lead to some issues for akita ng fire. This is not an akita bug, it is by design.
Example:
- you remove a key in firestore console and you won't see any changes on the page. You need to reload the page to see the effect.

This is why we need to purge the keys. Since in firestore, you only can update whole documents and not single keys. That being said, you want to purge the keys from the store that has been removed for instance. We can't delete a key from an akita store, but we can set them to undefined. 

close #119 