### PR TITLE
Bugfix: Add entity id to store update

### DIFF
--- a/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
+++ b/projects/akita-ng-fire/src/lib/utils/sync-from-action.ts
@@ -41,7 +41,7 @@ export function updateStoreEntity(removeAndAdd: boolean, storeName: string, enti
       upsertStoreEntity(storeName, data, entityIds)
     })
   } else {
-    runEntityStoreAction(storeName, EntityStoreAction.UpdateEntities, update => update(data))
+    runEntityStoreAction(storeName, EntityStoreAction.UpdateEntities, update => update(entityIds, data))
   }
 }
 


### PR DESCRIPTION
**Type**
Solves issue #135

**Description**
This passes the updated entity to the store, such that the entity instead of the store itself is updated. 

**Notes**
I tested this by manually running an 
`runEntityStoreAction(storeName, EntityStoreAction.UpdateEntities, update => update(entityIds, data))`
in my application, not via this library. So I am not sure if this fix covers all cases of `akita-ng-fire`. Notable, `entityIds` is a `string | string[]` and I am not sure if this works for `string[]`