### PR TITLE
Use correct firebase import

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,8 @@
 # Breaking Changes & Deprecations
 
+## 3.1.7
+With version 3.1.7, you need to update your firebase version >= 8 and your @angular/fire >= 6.0.4, since firebase change from CommonJs to EMS.
+
 ## 3.0.0
 
 With version v3, you need to update your akita version >=5.1.1, since there where breaking changes in the event-based-API from akita. 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,7 +1,7 @@
 # Breaking Changes & Deprecations
 
 ## 3.1.7
-With version 3.1.7, you need to update your firebase version >= 8 and your @angular/fire >= 6.0.4, since firebase change from CommonJs to EMS.
+With version 3.1.7, you need to update your firebase version >= 8 and your @angular/fire >= 6.0.4, firebase 8 now uses EMS instead of CommonJs.
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ### 3.1.7
-Update to firebase version >= 8 and @angular/fire >= 6.0.4, since firebase change from CommonJs to EMS.
+Update peerDependencies firebase to version >= 8 and @angular/fire to version >= 6.0.4, firebase 8 now uses EMS instead of CommonJs.
 
 ### 3.1.6
 Removed export from public api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### 3.1.7
+Update to firebase version >= 8 and @angular/fire >= 6.0.4, since firebase change from CommonJs to EMS.
+
 ### 3.1.6
 Removed export from public api
 

--- a/projects/akita-ng-fire/package.json
+++ b/projects/akita-ng-fire/package.json
@@ -5,9 +5,9 @@
     "@angular/common": ">=6.0.0 <11",
     "@angular/core": ">=6.0.0 <11",
     "@angular/router": ">=6.0.0 <11",
-    "@angular/fire": ">=6.0.0",
+    "@angular/fire": ">=6.0.4",
     "@datorama/akita": ">= 5.1.1",
-    "firebase": ">= 7.6.1 <8",
+    "firebase": ">= 8 <9",
     "typescript": ">= 3.6.4"
   },
   "author": "GrandSchtroumpf",

--- a/projects/akita-ng-fire/src/lib/collection/collection.service.spec.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.service.spec.ts
@@ -4,6 +4,7 @@ import { AngularFirestore, SETTINGS } from '@angular/fire/firestore';
 import { EntityStore, QueryEntity, StoreConfig, EntityState, ActiveState } from '@datorama/akita';
 import { Injectable } from '@angular/core';
 import firebase from 'firebase/app';
+import 'firebase/firestore';
 import { interval } from 'rxjs';
 import { switchMap, map, finalize, takeWhile } from 'rxjs/operators';
 import { AngularFireModule } from '@angular/fire';

--- a/projects/akita-ng-fire/src/lib/collection/collection.service.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.service.ts
@@ -14,6 +14,7 @@ import {
   getEntityType,
 } from '@datorama/akita';
 import firebase from 'firebase/app';
+import 'firebase/firestore';
 import { getIdAndPath } from '../utils/id-or-path';
 import {
   syncStoreFromDocAction,


### PR DESCRIPTION
In the #164, i removed the import 'firebase/firestore'; and I should have let them.

Reading the release note https://firebase.google.com/support/release-notes/js
Only the first line of import should have changed.

Before 8.0.0
import * as firebase from 'firebase/app'

After 8.0.0
import firebase from 'firebase/app'

+ I have updated Breaking change file + changelog file