### PR TITLE
Missing format from firestore when receiving updates

### DIFF
--- a/projects/akita-ng-fire/src/lib/utils/query/sync-query.ts
+++ b/projects/akita-ng-fire/src/lib/utils/query/sync-query.ts
@@ -215,7 +215,8 @@ export function syncQuery<E>(
           break;
         }
         case 'modified': {
-          this['store'].update(id, data);
+          const entity = this.formatFromFirestore(data);
+          this['store'].update(id, entity);
         }
       }
     }


### PR DESCRIPTION
When using syncQuery with a child query, the main query is not formatted from firestore upon receiving updates.