### PR TITLE
fix: loading state does not work with syncing empty collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "emulator:set": "firebase setup:emulators:firestore && firebase setup:emulators:database",
     "emulator": "firebase emulators:start",
     "test": "ng test",
+    "test:akita-ng-fire": "ng test akita-ng-fire",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "publish:latest": "cp ./README.md ./projects/akita-ng-fire/ && npm run build:akita-ng-fire && cd ./dist/akita-ng-fire && npm publish --tag latest",

--- a/projects/akita-ng-fire/src/lib/collection/collection.service.spec.ts
+++ b/projects/akita-ng-fire/src/lib/collection/collection.service.spec.ts
@@ -1,10 +1,6 @@
 // noinspection ES6PreferShortImport
-import {CollectionService} from './collection.service';
-import {createServiceFactory, SpectatorService, SpyObject} from '@ngneat/spectator';
-import {ActiveState, EntityState, EntityStore, QueryEntity, StoreConfig} from '@datorama/akita';
-import {Injectable} from '@angular/core';
-import {interval, lastValueFrom} from 'rxjs';
-import {first, map, switchMap, take, tap} from 'rxjs/operators';
+import { Injectable } from '@angular/core';
+import { getApp, initializeApp, provideFirebaseApp } from '@angular/fire/app';
 import {
   addDoc,
   collection,
@@ -23,7 +19,11 @@ import {
   SnapshotMetadata,
   where
 } from '@angular/fire/firestore';
-import {getApp, initializeApp, provideFirebaseApp} from '@angular/fire/app';
+import { ActiveState, EntityState, EntityStore, QueryEntity, StoreConfig } from '@datorama/akita';
+import { createServiceFactory, SpectatorService, SpyObject } from '@ngneat/spectator';
+import { firstValueFrom, interval, lastValueFrom } from 'rxjs';
+import { first, map, switchMap, take, tap } from 'rxjs/operators';
+import { CollectionService } from './collection.service';
 
 interface Movie {
   title: string;
@@ -229,6 +229,19 @@ describe('CollectionService', () => {
     const hasId = store['_value']().ids.includes('1');
     sub.unsubscribe();
     expect(hasId).toBeTruthy();
+  });
+
+
+  it('SyncCollection store loading', async () => {
+    let firstValue = await firstValueFrom(service.syncCollection());
+    expect(firstValue).toEqual([]);
+    expect(store['_value']().loading).toBeFalsy();
+    const sub = service.syncCollection().subscribe();
+    await service.add({ id: '1', title: 'Star Wars' });
+    const hasId = store['_value']().ids.includes('1');
+    sub.unsubscribe();
+    expect(hasId).toBeTruthy();
+    expect(store['_value']().loading).toBeFalsy();
   });
 
   it('SyncCollection with query constraints', async () => {

--- a/projects/akita-ng-fire/src/lib/utils/firestore.ts
+++ b/projects/akita-ng-fire/src/lib/utils/firestore.ts
@@ -8,10 +8,10 @@ import {
   SnapshotListenOptions,
   snapToData
 } from '@angular/fire/firestore';
-import {Observable} from 'rxjs';
-import {filter, map} from 'rxjs/operators';
+import { Observable, OperatorFunction, pipe, UnaryFunction } from 'rxjs';
+import { filter, map, pairwise, startWith } from 'rxjs/operators';
 
-export {fromRef as docSnapshotChanges};
+export { fromRef as docSnapshotChanges };
 
 export function docValueChanges<T>(ref: DocumentReference<T>, options: SnapshotListenOptions): Observable<T> {
   return fromRef<T>(ref, options)
@@ -32,10 +32,39 @@ export interface CollectionChangeListenOptions extends SnapshotListenOptions {
   events?: DocumentChangeType[];
 }
 
-export function collectionChanges<T>(query: Query<T>, options: CollectionChangeListenOptions): Observable<DocumentChange<T>[]> {
-  return !options.includeMetadataChanges ? fromRef<T>(query, options)
-    .pipe(
-      map(snapshot => snapshot.docChanges()),
-      filter(changes => changes.length > 0)
-    ) : rxfireCollectionChanges(query, options);
+/**
+ * Create an operator that allows you to compare the current emission with
+ * the prior, even on first emission (where prior is undefined).
+ */
+const windowwise = <T = unknown>() =>
+  pipe(
+    startWith(undefined),
+    pairwise() as OperatorFunction<T | undefined, [T | undefined, T]>
+  );
+
+/**
+ * Create an operator that filters out empty changes. We provide the
+ * ability to filter on events, which means all changes can be filtered out.
+ * This creates an empty array and would be incorrect to emit.
+ */
+const filterEmptyUnlessFirst = <T = unknown>(): UnaryFunction<
+  Observable<T[]>,
+  Observable<T[]>
+> =>
+  pipe(
+    windowwise(),
+    filter(([prior, current]) => current.length > 0 || prior === undefined),
+    map(([, current]) => current)
+  );
+
+export function collectionChanges<T>(
+  query: Query<T>,
+  options: CollectionChangeListenOptions
+): Observable<DocumentChange<T>[]> {
+  return !options.includeMetadataChanges
+    ? fromRef<T>(query, options).pipe(
+        map((snapshot) => snapshot.docChanges()),
+        filterEmptyUnlessFirst()
+      )
+    : rxfireCollectionChanges(query, options);
 }


### PR DESCRIPTION
fixes #238 

This ports the changes from [this suggested patch](https://github.com/angular/angularfire/issues/3242#issuecomment-1202552438) of rxfire.

This fix only works when `includeMetadataChanges` is `false`. When `true` then `collectionChanges` is [used directly](https://github.com/dappsnation/akita-ng-fire/blob/v7/projects/akita-ng-fire/src/lib/utils/firestore.ts#L40) and as such requires [the suggested patch](https://github.com/angular/angularfire/issues/3242#issuecomment-1202552438) of rxfire to work around.

I've had a go at adding a test which seems to prove that there is no emission on an empty collection without this change, and as such the test fails with a timeout. Not sure if there is a neater way to avoid failing on a timeout and actually asserting on the store loading state.